### PR TITLE
docs(java): remover parenteses do título

### DIFF
--- a/java.md
+++ b/java.md
@@ -1,8 +1,8 @@
-# public class JavaStyleGuide() {
+# public class JavaStyleGuide {
 
 ### ____Indentação
 
-* Indente o código com 1 tab, não com espaços:
+* Indente o código com tabs ao invés de espaços:
 ```java
 public void certo() {
 ____System.out.print("Certo");


### PR DESCRIPTION
Mudança puramente estética do guia, pois não existem parenteses na declaração de classes no java (apenas durante a instanciação de objetos).

Também fiz uma pequena alteração no texto da regra de indentenção, mas a regra continua a mesma.